### PR TITLE
Add a "Total Cost" column for convenience & use generator for returning data

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -32,19 +32,26 @@ build:
             ini:
                 'always_populate_raw_post_data': '-1'
 
-    tests:
-        override:
-            - bin/phpspec run --no-interaction --format=pretty
-            - bin/behat --no-interaction --no-snippets --stop-on-failure --format=pretty
-        after:
-            - SCRUTINIZER_START_TIME=$(cat /tmp/build-start-time.txt) sh -c 'curl -sS https://gist.githubusercontent.com/tonypiper/fd3cf9a67b71d4e3928c/raw/152f1d873f98ff4256ca8bc3041443eae7c890b4/keenio-logger.php | php'
+    nodes:
+        analysis:
+            tests:
+                override:
+                - php-scrutinizer-run
 
-    dependencies:
-        before:
-            - date -u +"%Y-%m-%dT%H:%M:%SZ" > /tmp/build-start-time.txt
+        tests-and-coverage:
+            tests:
+                override:
+                    - bin/phpspec run --no-interaction --format=pretty
+                    - bin/behat --no-interaction --no-snippets --stop-on-failure --format=pretty
+                after:
+                    - SCRUTINIZER_START_TIME=$(cat /tmp/build-start-time.txt) sh -c 'curl -sS https://gist.githubusercontent.com/tonypiper/fd3cf9a67b71d4e3928c/raw/152f1d873f98ff4256ca8bc3041443eae7c890b4/keenio-logger.php | php'
 
-        override:
-            - { command: 'composer update --no-interaction --prefer-source', idle_timeout: 600 }
+            dependencies:
+                before:
+                    - date -u +"%Y-%m-%dT%H:%M:%SZ" > /tmp/build-start-time.txt
+
+                override:
+                    - { command: 'composer update --no-interaction --prefer-source', idle_timeout: 600 }
 
     cache:
         directories: [ vendor/, bin/ ]

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -28,7 +28,7 @@ filter:
 build:
     environment:
         php:
-            version: 5.4
+            version: 5.5
             ini:
                 'always_populate_raw_post_data': '-1'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 sudo: false
 
-php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2]
+php: [5.5, 5.6, 7.0, 7.1, 7.2]
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "behat/behat": "^3.0.0",
         "symfony/filesystem": ">=2.3 || ^3.0.0"
     },

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -41,7 +41,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function iShouldSeeTheStepTimesOnTheConsole()
     {
-       $this->iShouldSeeTheMessage('| Average execution Time | Called count | Step name');
+       $this->iShouldSeeTheMessage('| Average execution Time | Called count | Total Cost | Step name');
     }
 
     /**

--- a/src/Bex/Behat/StepTimeLoggerExtension/Listener/StepTimeLoggerListener.php
+++ b/src/Bex/Behat/StepTimeLoggerExtension/Listener/StepTimeLoggerListener.php
@@ -71,13 +71,11 @@ final class StepTimeLoggerListener implements EventSubscriberInterface
     public function suiteFinished()
     {
         if ($this->config->isEnabled()) {
-            $calledCounts = $this->stepTimeLogger->getCalledCounts();
-            $avgTimes = $this->stepTimeLogger->getAvegrageExecutionTimes();
-            $this->stepTimeLogger->clearLogs();
-
             foreach ($this->config->getOutputPrinters() as $printer) {
-                $printer->printLogs($calledCounts, $avgTimes);
+                $printer->printLogs($this->stepTimeLogger->executionInformationGenerator());
             }
+
+            $this->stepTimeLogger->clearLogs();
         }
     }
 }

--- a/src/Bex/Behat/StepTimeLoggerExtension/Service/OutputPrinter/Console.php
+++ b/src/Bex/Behat/StepTimeLoggerExtension/Service/OutputPrinter/Console.php
@@ -12,7 +12,7 @@ class Console implements OutputPrinterInterface
      * @var ConsoleOutput
      */
     private $output;
-    
+
     /**
      * @param ConsoleOutput $output
      */
@@ -20,7 +20,7 @@ class Console implements OutputPrinterInterface
     {
         $this->output = $output;
     }
-    
+
     /**
      * @param Config $config
      */
@@ -30,17 +30,16 @@ class Console implements OutputPrinterInterface
     }
 
     /**
-     * @param  array $calledCounts
-     * @param  array $avgTimes
+     * @param \Generator $avgTimes
      *
      * @return void
      */
-    public function printLogs(array $calledCounts, array $avgTimes)
+    public function printLogs(\Generator $avgTimes)
     {
         $table = new Table($this->output);
-        $table->setHeaders(['Average execution Time', 'Called count', 'Step name']);
-        foreach ($avgTimes as $stepName => $time) {
-            $table->addRow([$time, $calledCounts[$stepName], $stepName]);
+        $table->setHeaders(['Average execution Time', 'Called count', 'Total Cost', 'Step name']);
+        foreach ($avgTimes as $stepName => $info) {
+            $table->addRow([$info['avg_execution_time'], $info['total_executions'], $info['total_cost'], $stepName]);
         }
         $table->render();
     }

--- a/src/Bex/Behat/StepTimeLoggerExtension/Service/OutputPrinter/Csv.php
+++ b/src/Bex/Behat/StepTimeLoggerExtension/Service/OutputPrinter/Csv.php
@@ -43,21 +43,20 @@ class Csv implements OutputPrinterInterface
     }
 
     /**
-     * @param  array $calledCounts
-     * @param  array $avgTimes
+     * @param \Generator $avgTimes
      *
      * @return void
      */
-    public function printLogs(array $calledCounts, array $avgTimes)
+    public function printLogs(\Generator $avgTimes)
     {
         $filePath = $this->getFilePath();
         $this->filesystem->dumpFile($filePath, '');
         $file = fopen($filePath, 'w');
 
-        fputcsv($file, ['Average execution Time', 'Called count', 'Step name']);
+        fputcsv($file, ['Average execution Time', 'Called count', 'Total Cost', 'Step name']);
 
-        foreach ($avgTimes as $stepName => $time) {
-            fputcsv($file, [$time, $calledCounts[$stepName], $stepName]);
+        foreach ($avgTimes as $stepName => $info) {
+            fputcsv($file, [$info['avg_execution_time'], $info['total_executions'], $info['total_cost'], $stepName]);
         }
 
         fclose($file);
@@ -75,5 +74,5 @@ class Csv implements OutputPrinterInterface
         return empty($path) ? $fileName : $path . DIRECTORY_SEPARATOR . $fileName;
     }
 
-    
+
 }

--- a/src/Bex/Behat/StepTimeLoggerExtension/Service/OutputPrinter/Csv.php
+++ b/src/Bex/Behat/StepTimeLoggerExtension/Service/OutputPrinter/Csv.php
@@ -53,6 +53,10 @@ class Csv implements OutputPrinterInterface
         $this->filesystem->dumpFile($filePath, '');
         $file = fopen($filePath, 'w');
 
+        if ($file === false) {
+            throw new \InvalidArgumentException(sprintf('Cannot open %s for writting', $filePath));
+        }
+
         fputcsv($file, ['Average execution Time', 'Called count', 'Total Cost', 'Step name']);
 
         foreach ($avgTimes as $stepName => $info) {

--- a/src/Bex/Behat/StepTimeLoggerExtension/Service/OutputPrinter/OutputPrinterInterface.php
+++ b/src/Bex/Behat/StepTimeLoggerExtension/Service/OutputPrinter/OutputPrinterInterface.php
@@ -14,10 +14,9 @@ interface OutputPrinterInterface
     public function configure(Config $config);
 
     /**
-     * @param  array $calledCounts
-     * @param  array $avgTimes
+     * @param \Generator $avgTimes
      *
      * @return void
      */
-    public function printLogs(array $calledCounts, array $avgTimes);
+    public function printLogs(\Generator $avgTimes);
 }

--- a/src/Bex/Behat/StepTimeLoggerExtension/Service/StepTimeLogger.php
+++ b/src/Bex/Behat/StepTimeLoggerExtension/Service/StepTimeLogger.php
@@ -65,7 +65,24 @@ class StepTimeLogger
         }
 
         arsort($avgTimes);
-        
+
         return $avgTimes;
-    }    
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function executionInformationGenerator()
+    {
+        foreach ($this->executionTimes as $stepName => $executionTimes) {
+            $totalExecutions = count($executionTimes);
+            $avgExecutionTime = round(array_sum($executionTimes) / $totalExecutions, 5);
+
+            yield $stepName => [
+                'avg_execution_time' => $avgExecutionTime,
+                'total_executions' => $totalExecutions,
+                'total_cost' => $avgExecutionTime * $totalExecutions
+            ];
+        }
+    }
 }


### PR DESCRIPTION
I'd like to propose an additional column containing total cost of the step (`avg execution time * executions). This is purely a convenience feature, for me it helps to pick lowest hanging fruits when analysing slow tests.

I've also trimmed the numbers to be just 5 precision for better readability.

Lastly I've added a generator instead of looping over arrays. That requires a minimum version bump towards 5.5.